### PR TITLE
Add Next.js site structure with pages and layout

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+import { ReactNode } from 'react';
+
+type Props = { children: ReactNode };
+
+export default function Layout({ children }: Props) {
+  return (
+    <>
+      <nav>
+        <Link href="/">Home</Link>
+        <Link href="/about">About</Link>
+        <Link href="/locations">Locations</Link>
+        <Link href="/membership">Membership</Link>
+        <Link href="/contact">Contact</Link>
+      </nav>
+      {children}
+      <footer>© 2025 The Courts Club</footer>
+    </>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import Layout from '../components/Layout';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,12 @@
+export default function About() {
+  return (
+    <main>
+      <h1>About Us</h1>
+      <p>
+        Founded in London, The Courts Club re-imagines racket sport culture.
+        We pair architectural beauty with pro-level facilities and a members-first
+        ethos. Our mission: elevate padel to an art form.
+      </p>
+    </main>
+  );
+}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,0 +1,9 @@
+export default function Contact() {
+  return (
+    <main>
+      <h1>Contact Us</h1>
+      <p>Email&nbsp;—&nbsp;<a href="mailto:hello@thecourtsclub.com">hello@thecourtsclub.com</a></p>
+      <p>Instagram&nbsp;—&nbsp;<a href="https://instagram.com/thecourtsclub">@thecourtsclub</a></p>
+    </main>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,11 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>The Courts Club</h1>
+      <p>
+        Welcome to The Courts Club – the world’s most elegant padel destination,
+        blending sport, design, and community.
+      </p>
+    </main>
+  );
+}

--- a/pages/locations.tsx
+++ b/pages/locations.tsx
@@ -1,0 +1,16 @@
+export default function Locations() {
+  return (
+    <main>
+      <h1>Our Locations</h1>
+
+      <h2>London</h2>
+      <p>Flagship riverside club with four indoor courts and a rooftop lounge.</p>
+
+      <h2>Paris</h2>
+      <p>Glass-walled courts in the heart of the 7ᵗʰ, steps from the Seine.</p>
+
+      <h2>Dubai</h2>
+      <p>Desert oasis venue featuring climate-controlled arenas and spa suites.</p>
+    </main>
+  );
+}

--- a/pages/membership.tsx
+++ b/pages/membership.tsx
@@ -1,0 +1,19 @@
+export default function Membership() {
+  return (
+    <main>
+      <h1>Membership</h1>
+      <p>
+        Limited to 500 global members. All tiers include court access,
+        concierge booking, and entry to tournaments and social events.
+      </p>
+
+      <ul>
+        <li><strong>Premier £3,000 / yr</strong> – Unlimited peak play, guest passes</li>
+        <li><strong>Weekday £1,800 / yr</strong> – Mon-Fri before 5 pm</li>
+        <li><strong>Junior £600 / yr</strong> – Under 18s, coaching included</li>
+      </ul>
+
+      <p>Enquire via <a href="mailto:membership@thecourtsclub.com">membership@thecourtsclub.com</a>.</p>
+    </main>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,29 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}
+nav {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 2rem;
+  background: #111;
+}
+nav a {
+  color: #ffffff;
+  text-decoration: none;
+  font-weight: 500;
+}
+nav a:hover {
+  text-decoration: underline;
+}
+main {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f2f2f2;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- create global styles for layout and typography
- add reusable `Layout` component with navigation and footer
- configure custom `_app` to wrap pages in the layout
- implement pages for home, about, locations, membership, and contact

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6865a05cff748332a7896f7b2481c51e